### PR TITLE
Handle longer floats in write_edf_header

### DIFF
--- a/ensemble_eeg/ensemble_edf.py
+++ b/ensemble_eeg/ensemble_edf.py
@@ -218,8 +218,19 @@ def write_edf_header(fd, header):
 
                 if not isinstance(val, bytes):
                     val = str(val).encode(encoding="ascii").ljust(size, b"\x20")
+                
+                if len(val) > size:
+                    try:
+                        # convert float to scientific expression
+                        val = float(val)
+                        if val >= 0:
+                            val = f'{val:.2e}'.encode(encoding="ascii").ljust(size, b"\x20")
+                        else:
+                            val = f'{val:.1e}'.encode(encoding="ascii").ljust(size, b"\x20")
+                    except:
+                        raise AssertionError(f"{val} too long! Need to be shorter than {size} bytes.")
 
-                assert len(val) == size
+                assert len(val) == size, f"{val} too long! Need to be shorter than {size} bytes."
                 fd.write(val)
 
     if opened:


### PR DESCRIPTION
There was an issue when trying to read then write files that had high absolute values for some of their header fields.

The issue was that what was written as scientific expression (e.g. -5.0E+06) was then converted to normal float (-5000000.0), which was then too long to be stored in the new header, causing an error.

The error is solved by adding a step checking if the binary is too long (more than the mandatory 8 bytes), then if it is a float, converting it to a scientific expression shorter than 8 bytes.
